### PR TITLE
avoid space in identifier

### DIFF
--- a/tools/Trinity/Trinity-V2.6.5.cwl
+++ b/tools/Trinity/Trinity-V2.6.5.cwl
@@ -42,7 +42,7 @@ inputs:
       itemSeparator: ","
       #separate: true
     label: 'right reads, one or more file names'
-  - id: single reads
+  - id: single_reads
     type: File?
     inputBinding:
       position: 4

--- a/workflows/TranscriptomeAssembly-wf.cwl
+++ b/workflows/TranscriptomeAssembly-wf.cwl
@@ -130,7 +130,7 @@ steps:
     in:
       left_reads: filter_reads/reads1_trimmed
       right_reads: filter_reads/reads2_trimmed_paired
-      single reads: filter_reads/reads1_trimmed
+      single_reads: filter_reads/reads1_trimmed
       max_mem: trinity_max_mem
       cpu: trinity_cpu
       seq_type: trinity_seq_type


### PR DESCRIPTION
CWL Viewer falls over with spaces in `id`:

```
file:///tmp/1542275784560-0/workflows/TranscriptomeAssembly-wf.cwl#run_assembly/single reads does not look like a valid URI, trying to serialize this will break.
file:///tmp/1542275784560-0/tools/Trinity/Trinity-V2.6.5.cwl#single reads does not look like a valid URI, trying to serialize this will break.
I'm sorry, I couldn't load this CWL file, try again with --debug for more information.
The error was: "file:///tmp/1542275784560-0/tools/Trinity/Trinity-V2.6.5.cwl#single reads" does not look like a valid URI, I cannot serialize this as N3/Turtle. Perhaps you wanted to urlencode it?
```

This fix renames `single reads` in Trinity tool.